### PR TITLE
23.10 - Allow opening new files into current helix session from the command line

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.27", features = ["event-stream"] }
 signal-hook = "0.3"
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["net"] }
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
 arc-swap = { version = "1.6.0" }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -40,6 +40,10 @@ use std::{collections::btree_map::Entry, io::stdin, path::Path, sync::Arc};
 use anyhow::{Context, Error};
 
 use crossterm::{event::Event as CrosstermEvent, tty::IsTty};
+
+#[cfg(unix)]
+use tokio::io::AsyncReadExt;
+
 #[cfg(not(windows))]
 use {signal_hook::consts::signal, signal_hook_tokio::Signals};
 #[cfg(windows)]
@@ -74,6 +78,9 @@ pub struct Application {
     signals: Signals,
     jobs: Jobs,
     lsp_progress: LspProgressMap,
+
+    #[cfg(unix)]
+    remote_listener: tokio_stream::wrappers::UnixListenerStream,
 }
 
 #[cfg(feature = "integration")]
@@ -231,6 +238,12 @@ impl Application {
         ])
         .context("build signal handler")?;
 
+        #[cfg(unix)]
+        let remote_listener = {
+            let listener = tokio::net::UnixListener::bind("/tmp/helix-socket").unwrap();
+            tokio_stream::wrappers::UnixListenerStream::new(listener)
+        };
+
         let app = Self {
             compositor,
             terminal,
@@ -244,6 +257,9 @@ impl Application {
             signals,
             jobs: Jobs::new(),
             lsp_progress: LspProgressMap::new(),
+
+            #[cfg(unix)]
+            remote_listener,
         };
 
         Ok(app)
@@ -317,6 +333,9 @@ impl Application {
                 Some(event) = input_stream.next() => {
                     self.handle_terminal_events(event).await;
                 }
+                Some(result) = self.remote_listener.next() => {
+                    self.handle_remote(result).await;
+                }
                 Some(callback) = self.jobs.futures.next() => {
                     self.jobs.handle_callback(&mut self.editor, &mut self.compositor, callback);
                     self.render().await;
@@ -343,6 +362,43 @@ impl Application {
             {
                 self.editor.reset_idle_timer();
             }
+        }
+    }
+
+    // Handles text messages coming in from a unix socket - currently only used to respond to
+    // 'open file' requests so that we can do that from the command line
+    pub async fn handle_remote(&mut self, result: Result<tokio::net::UnixStream, std::io::Error>) {
+        match result {
+            Ok(mut unix_stream) => {
+                let mut buffer = Vec::new();
+                let _ = unix_stream.read_to_end(&mut buffer).await;
+
+                let contents = String::from_utf8_lossy(&buffer);
+
+                let parts: Vec<_> = contents.split(' ').collect();
+                if parts[0] == "open" {
+                    let file_path = parts[1];
+                    let command = crate::commands::MappableCommand::Typable {
+                        name: "open".to_string(),
+                        args: vec![file_path.trim().to_string()],
+                        doc: String::new(),
+                    };
+
+                    let mut context = crate::commands::Context {
+                        editor: &mut self.editor,
+                        count: None,
+                        register: None,
+                        callback: None,
+                        on_next_key_callback: None,
+                        jobs: &mut self.jobs,
+                    };
+
+                    command.execute(&mut context);
+
+                    self.render().await;
+                }
+            }
+            _ => {}
         }
     }
 


### PR DESCRIPTION
Using Unix socket as a communication device. Only works on unix and isn't even marked up properly at the moment so compliation on windows will fail.

I have no expectations of this making it into the project. It is just a quick hack.
