### PR TITLE
24.03 - Allow opening new files into current helix session from the command line

### DIFF
--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.27", features = ["event-stream"] }
 signal-hook = "0.3"
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["net"] }
 futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
 arc-swap = { version = "1.7.1" }
 termini = "1"


### PR DESCRIPTION
Using Unix socket as a communication device. Only works on unix and isn't even marked up properly at the moment so compliation on windows will fail.

I have no expectations of this making it into the project. It is just a quick hack.